### PR TITLE
refactor: changed private entity properties to protected

### DIFF
--- a/src/Entity/Article.php
+++ b/src/Entity/Article.php
@@ -13,14 +13,14 @@ use Sylius\Component\Core\Model\AdminUserInterface;
 class Article extends BaseArticle implements ArticleInterface
 {
     /** @var AdminUserInterface|null */
-    private $author;
+    protected $author;
 
     /**
      * @var Collection|ChannelInterface[]
      *
      * @psalm-var Collection<array-key, ChannelInterface>
      */
-    private $channels;
+    protected $channels;
 
     public function __construct()
     {

--- a/src/Entity/ArticleComment.php
+++ b/src/Entity/ArticleComment.php
@@ -10,7 +10,7 @@ use Sylius\Component\Core\Model\ShopUserInterface;
 class ArticleComment extends BaseArticleComment implements ArticleCommentInterface
 {
     /** @var ShopUserInterface|null */
-    private $author;
+    protected $author;
 
     /**
      * {@inheritdoc}


### PR DESCRIPTION
Changed to entity properties to protected (from private), so extending classes don't need to redefine the properties and getters and setts for it.